### PR TITLE
Feature/krouly create scaffolds app and intro krouly run

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -2,8 +2,9 @@ module krouly/cli
 
 go 1.21.4
 
+require github.com/spf13/cobra v1.8.0
+
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 )

--- a/cli/main.go
+++ b/cli/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 )
@@ -14,17 +16,112 @@ var rootCmd = &cobra.Command{
 
 var createCmd = &cobra.Command{
 	Use:   "create [name]",
-	Short: "Create a new data extraction workflow",
+	Short: "Create a new data extraction client",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		name := args[0]
-		fmt.Printf("Creating data extraction workflow: %s\n", name)
-		// Add logic to create a new data extraction workflow
+		fmt.Printf("Creating data extraction workflow app: %s\n", name)
+
+		clientDir := filepath.Join("..", "client", name)
+		if err := os.MkdirAll(clientDir, 0755); err != nil {
+			fmt.Println(err)
+			return
+		}
+
+		// Install Preact and Preact Router in the client directory
+		if err := installPreact(clientDir); err != nil {
+			fmt.Println(err)
+			return
+		}
+
+		// Generate Preact files in the client directory
+		if err := generateMainJS(clientDir, name); err != nil {
+			fmt.Println(err)
+			return
+		}
+		if err := generateIndexHTML(clientDir, name); err != nil {
+			fmt.Println(err)
+			return
+		}
+
+		fmt.Println("Preact setup completed successfully.")
 	},
+}
+
+var runCmd = &cobra.Command{
+	Use:   "run [name]",
+	Short: "Run the Preact app",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		name := args[0]
+		fmt.Printf("Running the Preact app for: %s\n", name)
+
+		clientDir := filepath.Join("..", "client", name) // Adjust app name and directory as needed
+		webappDir := filepath.Join(clientDir, "webapp")
+
+		runCommand := exec.Command("npm", "start")
+		runCommand.Dir = webappDir
+		runCommand.Stdout = os.Stdout
+		runCommand.Stderr = os.Stderr
+		if err := runCommand.Run(); err != nil {
+			fmt.Println(err)
+			return
+		}
+	},
+}
+
+func installPreact(targetDir string) error {
+	cmd := exec.Command("npm", "install", "preact", "preact-router")
+	cmd.Dir = targetDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to install Preact in %s: %v\n%s", targetDir, err, output)
+	}
+	return nil
+}
+
+func generateMainJS(targetDir, name string) error {
+	mainJS := `import { h, render } from 'preact';
+import App from './components/App';
+
+render(<App />, document.getElementById('root'));`
+	err := os.MkdirAll(filepath.Join(targetDir, "webapp", "static", "js"), 0755)
+	if err != nil {
+		return fmt.Errorf("failed to create directory: %v", err)
+	}
+	err = os.WriteFile(filepath.Join(targetDir, "webapp", "static", "js", "main.js"), []byte(mainJS), 0644)
+	if err != nil {
+		return fmt.Errorf("failed to generate main.js: %v", err)
+	}
+	return nil
+}
+
+func generateIndexHTML(targetDir, name string) error {
+	indexHTML := fmt.Sprintf(`<html>
+<head>
+	<title>%s - Powered by Preact</title>
+	<script src="/static/js/preact.min.js"></script>
+	<script src="/static/js/preact-router.min.js"></script>
+</head>
+<body>
+	<div id="root">Hi friend! My name is %s.</div>
+	<script src="/static/js/main.js"></script>
+</body>
+</html>`, name, name)
+	err := os.MkdirAll(filepath.Join(targetDir, "webapp", "views"), 0755)
+	if err != nil {
+		return fmt.Errorf("failed to create directory: %v", err)
+	}
+	err = os.WriteFile(filepath.Join(targetDir, "webapp", "views", "index.html"), []byte(indexHTML), 0644)
+	if err != nil {
+		return fmt.Errorf("failed to generate index.html: %v", err)
+	}
+	return nil
 }
 
 func main() {
 	rootCmd.AddCommand(createCmd)
+	rootCmd.AddCommand(runCmd)
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)


### PR DESCRIPTION
> IMPORTANT: `krouly` command itself **is not yet available**. In order to test it you have to go inside the `cli` folder and run the go package `go run main.go <command> <args>`.

Example: 
Instead of running `krouly create appname` you will run `go run main.go create appname` inside the `cli` folder

# Description
`krouly run`
`krouly create`
 
This will generate a folder named `testing` inside `client` folder when running `krouly create <app-name>`

E.g. `krouly create testing` will install preact, preact rounter and generate a basic app

```
└── testing
    │   ├── preact
    │   └── preact-router
    ├── package-lock.json
    ├── package.json
    └── webapp
        ├── static
        └── views
```


After generating the app you can run it by running `krouly run`. 

You might find issues as ~~npm install is not ran when you scaffold the app~~ seems that there is no start script. Go to to `client/yourapp` and run `npm install` then try again running `krouly run` inside the `cli` folder.

This is not mandatory you can run the app using preact command.


